### PR TITLE
Dont require patchlevel of Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.0'
+ruby '~> 2.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2', '>= 6.0.2.1'


### PR DESCRIPTION
Otherwise, installation currently fails, as it already pulls/uses Ruby 2.7.2 in the course of docker-compose